### PR TITLE
Fix US keyboard layout

### DIFF
--- a/data/keyboard_layouts/us.json
+++ b/data/keyboard_layouts/us.json
@@ -28,7 +28,8 @@
       {"base": "o", "shift": "O", "altgr": "ó", "finger": "right_ring"},
       {"base": "p", "shift": "P", "altgr": "ö", "finger": "right_pinky"},
       {"base": "[", "shift": "{", "altgr": "«", "finger": "right_pinky"},
-      {"base": "]", "shift": "}", "altgr": "»", "finger": "right_pinky"}
+      {"base": "]", "shift": "}", "altgr": "»", "finger": "right_pinky"},
+      {"base": "\\", "shift": "|", "altgr": "¬", "finger": "right_pinky"}
     ],
     [
       {"base": "a", "shift": "A", "altgr": "á", "finger": "left_pinky"},
@@ -41,11 +42,9 @@
       {"base": "k", "shift": "K", "altgr": "ĸ", "finger": "right_middle"},
       {"base": "l", "shift": "L", "altgr": "ł", "finger": "right_ring"},
       {"base": ";", "shift": ":", "altgr": "¶", "finger": "right_pinky"},
-      {"base": "'", "shift": "\"", "altgr": "´", "finger": "right_pinky"},
-      {"base": "\\", "shift": "|", "altgr": "¬", "finger": "right_pinky"}
+      {"base": "'", "shift": "\"", "altgr": "´", "finger": "right_pinky"}
     ],
     [
-      {"base": "<", "shift": ">", "altgr": "", "finger": "left_pinky"},
       {"base": "z", "shift": "Z", "altgr": "æ", "finger": "left_pinky"},
       {"base": "x", "shift": "X", "altgr": "×", "finger": "left_ring"},
       {"base": "c", "shift": "C", "altgr": "©", "finger": "left_middle"},


### PR DESCRIPTION
[Per Wikipedia](https://en.wikipedia.org/wiki/QWERTY#US-International), this is the common ANSI QWERTY keyboard layout used in the US:

<img width="960" height="320" alt="ANSI QWERTY US" src="https://github.com/user-attachments/assets/2477c7c6-c133-44cd-b2b8-e27c337f52c3" />

Specific changes from current `us.json` config:

- `\` should be at the end of the second row, after the square brackets
- There's no `<` key between left shift and `z` on the fourth row